### PR TITLE
Fixed logo size for header and footer

### DIFF
--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -26,7 +26,7 @@ const Footer: FC<Props> = async ({ locale }) => {
     <footer className="bg-secondary/40 py-10 md:py-20 pb-[99px] lg:pb-20">
       <MaxWidthWrapper className="flex items-center md:items-start flex-col md:flex-row gap-10 justify-between">
         <div className="max-w-xs flex flex-col items-center md:items-start gap-4 md:gap-6">
-          <Media resource={footer.logo} height={100} width={100} className="h-[40px] w-auto" />
+          <Media resource={footer.logo} height={100} width={100} className="h-[80px] w-auto" />
           <div className="space-y-4 mt-8">
             {contacts.contacts?.map((contact) => (
               <Link href={contact.url} className="flex items-center gap-3" key={contact.id}>

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -48,7 +48,7 @@ const Header = async ({ locale }: HeaderProps) => {
                 <Logo
                   src={(headerData.logo as Media).url!}
                   alt={(headerData.logo as Media).alt}
-                  className="h-[40px]"
+                  className="h-[65px]"
                 />
               </Link>
             </div>


### PR DESCRIPTION
This pull request includes changes to the `Footer` and `Header` components to update the logo sizes for better visual consistency.

Changes to logo sizes:

* [`src/components/Footer/index.tsx`](diffhunk://#diff-690031c63c881f194e793d09ea7a366a62b3cc37962f1a81fe5396274deeaec4L29-R29): Updated the height of the logo in the `Footer` component from 40px to 80px.
* [`src/components/Header/index.tsx`](diffhunk://#diff-b74d58497974281b6e8d776b73cf7610aca5082355bbb47d06e632f0c92cd1dfL51-R51): Updated the height of the logo in the `Header` component from 40px to 65px.