### PR TITLE
style: enhance MobileDrawer layout for improved scrolling and visibility

### DIFF
--- a/src/components/Header/MobileDrawer/index.tsx
+++ b/src/components/Header/MobileDrawer/index.tsx
@@ -42,29 +42,31 @@ const MobileDrawer: FC<MobileDrawerProps> = ({ data, locale, treatments }) => {
           <Menu className="size-8" />
         </Button>
       </DrawerTrigger>
-      <DrawerContent>
-        <DrawerHeader>
+      <DrawerContent className="max-h-[85vh] flex flex-col">
+        <DrawerHeader className="flex-shrink-0">
           <DrawerTitle>Menu</DrawerTitle>
         </DrawerHeader>
-        <motion.div
-          className="px-4 pb-8 flex flex-col divide-y"
-          variants={containerVariants}
-          initial="hidden"
-          animate="show"
-        >
-          {data.links.map((link) =>
-            link.hasChildren || link.showTreatments ? (
-              <MobileNavLinkWithChildren
-                key={link.id}
-                data={link}
-                locale={locale}
-                treatments={treatments}
-              />
-            ) : (
-              <MobileNavLinkWithoutChildren key={link.id} data={link} />
-            ),
-          )}
-        </motion.div>
+        <div className="flex-1 overflow-y-auto">
+          <motion.div
+            className="px-4 pb-8 flex flex-col divide-y"
+            variants={containerVariants}
+            initial="hidden"
+            animate="show"
+          >
+            {data.links.map((link) =>
+              link.hasChildren || link.showTreatments ? (
+                <MobileNavLinkWithChildren
+                  key={link.id}
+                  data={link}
+                  locale={locale}
+                  treatments={treatments}
+                />
+              ) : (
+                <MobileNavLinkWithoutChildren key={link.id} data={link} />
+              ),
+            )}
+          </motion.div>
+        </div>
       </DrawerContent>
     </Drawer>
   )


### PR DESCRIPTION
This pull request includes updates to the `MobileDrawer` component to improve its layout and responsiveness. The most important changes are:

Layout improvements:

* [`src/components/Header/MobileDrawer/index.tsx`](diffhunk://#diff-6addcd11168239cf2f40c0340914d2fe05a18de8605ff65664d00a96f55e8910L45-R49): Added `max-h-[85vh] flex flex-col` class to `DrawerContent` to limit its height and enable a flexible column layout.
* [`src/components/Header/MobileDrawer/index.tsx`](diffhunk://#diff-6addcd11168239cf2f40c0340914d2fe05a18de8605ff65664d00a96f55e8910L45-R49): Added `flex-shrink-0` class to `DrawerHeader` to prevent it from shrinking.
* [`src/components/Header/MobileDrawer/index.tsx`](diffhunk://#diff-6addcd11168239cf2f40c0340914d2fe05a18de8605ff65664d00a96f55e8910L45-R49): Wrapped the motion div in a `div` with `flex-1 overflow-y-auto` class to allow scrolling within the content area. [[1]](diffhunk://#diff-6addcd11168239cf2f40c0340914d2fe05a18de8605ff65664d00a96f55e8910L45-R49) [[2]](diffhunk://#diff-6addcd11168239cf2f40c0340914d2fe05a18de8605ff65664d00a96f55e8910R69)