### PR TITLE
style: add admin descriptions for images in PatientSafetyBlock and adjust aspect ratios

### DIFF
--- a/src/blocks/PatientSafetyBlock.ts
+++ b/src/blocks/PatientSafetyBlock.ts
@@ -36,6 +36,9 @@ export const PatientSafetyBlock: Block = {
           filterOptions: {
             mimeType: { contains: 'image' },
           },
+          admin: {
+            description: 'The image that will be displayed on larger screens',
+          },
         },
         {
           type: 'upload',
@@ -45,6 +48,9 @@ export const PatientSafetyBlock: Block = {
           required: true,
           filterOptions: {
             mimeType: { contains: 'image' },
+          },
+          admin: {
+            description: 'The image that will be displayed on mobile screens',
           },
         },
         {
@@ -79,6 +85,9 @@ export const PatientSafetyBlock: Block = {
             mimeType: { contains: 'image' },
           },
           label: 'Image',
+          admin: {
+            description: 'Image will be rendered with a 6:3 aspect ratio',
+          },
         },
         {
           type: 'text',

--- a/src/components/Blocks/PatientSafety/index.tsx
+++ b/src/components/Blocks/PatientSafety/index.tsx
@@ -42,12 +42,12 @@ const PatientSafetyBlockComponent: FC<Props> = ({ data }) => {
 
           {data.points.map((point) => (
             <div key={point.id} className="flex flex-col h-full">
-              <div className="h-60 relative">
+              <div className="max-h-60 relative aspect-[4/3]">
                 <Media
                   resource={point.image}
                   height={300}
                   width={600}
-                  className="w-full h-full object-cover absolute inset-0"
+                  className="w-full h-full object-cover absolute inset-0 aspect-[6/3]"
                 />
               </div>
               <div className="mt-4 flex flex-col text-center flex-1 flex-grow">

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -601,12 +601,21 @@ export interface PatientSafetyBlock {
     [k: string]: unknown;
   };
   intro: {
+    /**
+     * The image that will be displayed on larger screens
+     */
     image: string | Media;
+    /**
+     * The image that will be displayed on mobile screens
+     */
     mobileImage: string | Media;
     title: string;
     description: string;
   };
   points: {
+    /**
+     * Image will be rendered with a 6:3 aspect ratio
+     */
     image: string | Media;
     title: string;
     description: string;


### PR DESCRIPTION
This pull request includes changes to the `PatientSafetyBlock` component and its associated types to enhance the descriptions and improve the rendering of images. The most important changes include adding admin descriptions for images, updating the image aspect ratio, and enhancing the type definitions.

Enhancements to image descriptions and rendering:

* [`src/blocks/PatientSafetyBlock.ts`](diffhunk://#diff-f16a0decb89b72688ee5aa30e0d6bc257d0cd3d0aafc5b4bdde27e5f94d09b96R39-R41): Added admin descriptions for images to provide context on their display on different screen sizes and aspect ratios. [[1]](diffhunk://#diff-f16a0decb89b72688ee5aa30e0d6bc257d0cd3d0aafc5b4bdde27e5f94d09b96R39-R41) [[2]](diffhunk://#diff-f16a0decb89b72688ee5aa30e0d6bc257d0cd3d0aafc5b4bdde27e5f94d09b96R52-R54) [[3]](diffhunk://#diff-f16a0decb89b72688ee5aa30e0d6bc257d0cd3d0aafc5b4bdde27e5f94d09b96R88-R90)

* [`src/components/Blocks/PatientSafety/index.tsx`](diffhunk://#diff-e000daad2d7147adcfb2d2388e939f2b19a1d0cc90f2ea51d35d236c2fa4b901L45-R50): Updated the `PatientSafetyBlockComponent` to use a specific aspect ratio for images and adjusted the CSS classes for better image rendering.
