### PR TITLE
feat: add TreatmentsRelationBlock for managing treatment relationships

### DIFF
--- a/src/app/(frontend)/[locale]/treatments/[slug]/treatmentJsxConverter.tsx
+++ b/src/app/(frontend)/[locale]/treatments/[slug]/treatmentJsxConverter.tsx
@@ -3,6 +3,7 @@ import ColorTextInlineBlockComponent from '@/components/Blocks/ColorTextBlock'
 import FAQSection from '@/components/Blocks/FAQBlock'
 import GridPriceListBlockComponent from '@/components/Blocks/GridPriceListBlock'
 import ImageBlockComponent from '@/components/Blocks/ImageBlock'
+import TreatmentsRelationBlockComponent from '@/components/Blocks/TreatmentsRelation'
 import YoutubeEmbedBlockComponent from '@/components/Blocks/YoutubeEmbedBlock'
 import {
   CheckListBlock,
@@ -10,6 +11,7 @@ import {
   FaqBlock,
   GridPriceListBlock,
   ImageBlock,
+  TreatmentsRelationBlock,
   YoutubeEmbedBlock,
 } from '@/payload-types'
 import { JSXConvertersFunction } from '@payloadcms/richtext-lexical/react'
@@ -34,6 +36,9 @@ export const treatmentJsxConverter: JSXConvertersFunction = ({ defaultConverters
       ),
       'color-text': ({ node }: { node: { fields: ColorTextBlock } }) => (
         <ColorTextInlineBlockComponent data={node.fields} />
+      ),
+      'treatments-relation': ({ node }: { node: { fields: TreatmentsRelationBlock } }) => (
+        <TreatmentsRelationBlockComponent data={node.fields} />
       ),
     },
   }

--- a/src/blocks/richtext/TreatmentsRelationBlock.ts
+++ b/src/blocks/richtext/TreatmentsRelationBlock.ts
@@ -1,0 +1,22 @@
+import { Block } from 'payload'
+
+export const TreatmentsRelationBlock: Block = {
+  slug: 'treatments-relation',
+  labels: {
+    singular: 'Treatments Relation',
+    plural: 'Treatments Relations',
+  },
+  interfaceName: 'TreatmentsRelationBlock',
+  fields: [
+    {
+      type: 'relationship',
+      name: 'treatments',
+      relationTo: 'treatments',
+      hasMany: true,
+      admin: {
+        isSortable: true,
+      },
+      minRows: 1,
+    },
+  ],
+}

--- a/src/collections/Treatments/index.ts
+++ b/src/collections/Treatments/index.ts
@@ -9,6 +9,7 @@ import { CollectionConfig } from 'payload'
 import { revalidateTreatment } from './hooks/revalidateTreatment'
 import { GridPriceListBlock } from '@/blocks/richtext/GridPriceListBlock'
 import { ColorTextBlock } from '@/blocks/richtext/ColorTextBlock'
+import { TreatmentsRelationBlock } from '@/blocks/richtext/TreatmentsRelationBlock'
 
 export const Treatments: CollectionConfig = {
   slug: 'treatments',
@@ -25,6 +26,13 @@ export const Treatments: CollectionConfig = {
   },
   hooks: {
     afterChange: [revalidateTreatment],
+  },
+  defaultPopulate: {
+    title: true,
+    icon: true,
+    thumbnail: true,
+    description: true,
+    slug: true,
   },
   fields: [
     {
@@ -110,6 +118,7 @@ export const Treatments: CollectionConfig = {
                         FaqBlock,
                         GridPriceListBlock,
                         ColorTextBlock,
+                        TreatmentsRelationBlock,
                       ],
                       inlineBlocks: [],
                     }),

--- a/src/components/Blocks/TreatmentsRelation.tsx
+++ b/src/components/Blocks/TreatmentsRelation.tsx
@@ -1,0 +1,20 @@
+import { Treatment, TreatmentsRelationBlock } from '@/payload-types'
+import React, { FC } from 'react'
+import TreatmentWrapper from '../Treatment/TreatmentWrapper'
+
+type Props = {
+  data: TreatmentsRelationBlock
+}
+
+const TreatmentsRelationBlockComponent: FC<Props> = ({ data }) => {
+  return (
+    data.treatments && (
+      <TreatmentWrapper
+        className="not-prose xl:grid-cols-3"
+        treatments={data.treatments as Treatment[]}
+      />
+    )
+  )
+}
+
+export default TreatmentsRelationBlockComponent

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -1490,6 +1490,16 @@ export interface ColorTextBlock {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "TreatmentsRelationBlock".
+ */
+export interface TreatmentsRelationBlock {
+  treatments?: (string | Treatment)[] | null;
+  id?: string | null;
+  blockName?: string | null;
+  blockType: 'treatments-relation';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "auth".
  */
 export interface Auth {

--- a/src/utilities/getCollection.ts
+++ b/src/utilities/getCollection.ts
@@ -28,6 +28,7 @@ export const getCollection = async (params: GetCollectionParams) => {
     select,
     page,
     depth,
+    draft: false,
   })
 
   return result

--- a/src/utilities/getTreatment.ts
+++ b/src/utilities/getTreatment.ts
@@ -20,7 +20,7 @@ export async function getTreatment({
         equals: slug,
       },
     },
-    depth: 1,
+    depth: 2,
     locale: locale,
     draft: draft,
     limit: 1,


### PR DESCRIPTION
This pull request introduces a new `TreatmentsRelationBlock` component and integrates it into the existing codebase. The changes include adding the new block component, updating the JSX converter, and modifying the collection configuration to support the new block.

### Integration of `TreatmentsRelationBlock`:

* `src/app/(frontend)/[locale]/treatments/[slug]/treatmentJsxConverter.tsx`: Imported `TreatmentsRelationBlockComponent` and updated the `treatmentJsxConverter` to handle the new block type. ([src/app/(frontend)/[locale]/treatments/[slug]/treatmentJsxConverter.tsxR6-R14](diffhunk://#diff-692e555067315ee35b90cdb6dc7b2c119cae0d3209c4a0d8cf5a96c926e93615R6-R14), [src/app/(frontend)/[locale]/treatments/[slug]/treatmentJsxConverter.tsxR40-R42](diffhunk://#diff-692e555067315ee35b90cdb6dc7b2c119cae0d3209c4a0d8cf5a96c926e93615R40-R42))
* [`src/components/Blocks/TreatmentsRelation.tsx`](diffhunk://#diff-e669a4592c8627695a05a35945624ba95c2ff4ca2db8cfec9270103a32ea31dcR1-R20): Created the `TreatmentsRelationBlockComponent` to render the treatments relation block.
* [`src/blocks/richtext/TreatmentsRelationBlock.ts`](diffhunk://#diff-9d3e619d415715020fe5263cb883a1a435a47d32106695d1d6fd03ad49acba82R1-R22): Defined the `TreatmentsRelationBlock` with the necessary fields and configuration.
* [`src/collections/Treatments/index.ts`](diffhunk://#diff-d273d6f8664bddcd62a180229bf24eb90bda68ed4e318e6c17822cd6c97bebf3R12): Added `TreatmentsRelationBlock` to the treatments collection configuration and updated the default populate fields. [[1]](diffhunk://#diff-d273d6f8664bddcd62a180229bf24eb90bda68ed4e318e6c17822cd6c97bebf3R12) [[2]](diffhunk://#diff-d273d6f8664bddcd62a180229bf24eb90bda68ed4e318e6c17822cd6c97bebf3R30-R36) [[3]](diffhunk://#diff-d273d6f8664bddcd62a180229bf24eb90bda68ed4e318e6c17822cd6c97bebf3R121)
* [`src/payload-types.ts`](diffhunk://#diff-5169b7635fb8b2fb179f5f8f4b754aa143d1a627cce5f6a0f9db79639ade7bb0R1491-R1500): Added the `TreatmentsRelationBlock` interface to the payload types.

### Other changes:

* [`src/utilities/getCollection.ts`](diffhunk://#diff-2f4df4cd81f566ada7804df793924bd3e140bdd92e1c2e42f12e7b3d51410b96R31): Set the `draft` parameter to `false` by default in the `getCollection` function.
* [`src/utilities/getTreatment.ts`](diffhunk://#diff-12a56238a01fc6ee3985fd2bd759c8f402b17e47901841d07c91770c2511e522L23-R23): Increased the `depth` parameter from 1 to 2 in the `getTreatment` function to fetch more detailed data.