### PR TITLE
fix: improve styling and responsiveness of CallToActionButtonsBlock

### DIFF
--- a/src/components/Blocks/CallToActionButtonsBlock.tsx
+++ b/src/components/Blocks/CallToActionButtonsBlock.tsx
@@ -16,11 +16,12 @@ const CallToActionButtonsBlockComponent: FC<Props> = ({ data }) => {
           asChild
           key={button.id}
           style={{ backgroundColor: button.color.bgColor, color: button.color.textColor }}
-          className="flex-1 text-lg h-16"
-          size="lg"
+          className="flex-1 text-base md:text-lg h-16 shrink-0 space-x-2 w-full"
         >
-          <Link href={button.url} className="space-x-2">
-            {button.icon && <Media resource={button.icon} height={30} width={30} />}
+          <Link href={button.url}>
+            {button.icon && (
+              <Media resource={button.icon} height={30} width={30} className="size-5 md:size-7" />
+            )}
             {button.label}
           </Link>
         </Button>


### PR DESCRIPTION
This pull request includes changes to the `CallToActionButtonsBlockComponent` in `src/components/Blocks/CallToActionButtonsBlock.tsx`. The primary goal of these changes is to improve the responsiveness and styling of the buttons within the component.

Styling improvements:

* Updated the `className` property of the `Button` component to include responsive text sizing (`text-base md:text-lg`), a non-shrinking behavior (`shrink-0`), and full width (`w-full`).
* Adjusted the `Link` component to remove the `space-x-2` class and added a responsive size class to the `Media` component (`size-5 md:size-7`).