### PR TITLE
VideoReviewCarousel: Change visible item in carousel from 3 to 2 on large screen

### DIFF
--- a/src/components/Blocks/CarouselReview/VideoReviewCarousel.tsx
+++ b/src/components/Blocks/CarouselReview/VideoReviewCarousel.tsx
@@ -22,7 +22,7 @@ const VideoReviewCarousel: FC<Props> = ({ data }) => {
 
       <ReviewCarousel className="mt-8">
         {filteredReviews?.map((review) => (
-          <CarouselItem className="lg:basis-1/3" key={review.id}>
+          <CarouselItem className="lg:basis-1/2" key={review.id}>
             <div className="py-1">
               <YoutubeEmbed
                 isActive


### PR DESCRIPTION
This pull request includes a small change to the `src/components/Blocks/CarouselReview/VideoReviewCarousel.tsx` file. The change modifies the class name for `CarouselItem` to adjust its basis from one-third to one-half.

* [`src/components/Blocks/CarouselReview/VideoReviewCarousel.tsx`](diffhunk://#diff-d1250920843ab93d162470bd3a670c771a3d52b37afcb6c6e7e54a4065ddd537L25-R25): Changed the class name for `CarouselItem` from `lg:basis-1/3` to `lg:basis-1/2` to alter the layout of the carousel items.