### PR TITLE
feat: enhance StatsSection layout with improved styling and border adjustments

### DIFF
--- a/src/components/Blocks/Stats/index.tsx
+++ b/src/components/Blocks/Stats/index.tsx
@@ -9,13 +9,16 @@ type Props = {
 
 const StatsSection: FC<Props> = ({ data }) => {
   return (
-    <div className="bg-primary/70 text-primary-foreground py-8 my-20">
+    <div className="bg-primary/70 text-primary-foreground my-20">
       <MaxWidthWrapper
         element="section"
-        className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-5"
+        className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 lg:divide-x p-0"
       >
         {data.stats?.map((stat) => (
-          <div key={stat.id} className="flex items-center flex-col justify-center">
+          <div
+            key={stat.id}
+            className="flex items-center flex-col justify-center border border-border lg:border-0 p-6"
+          >
             <Media
               resource={stat.icon}
               height={80}


### PR DESCRIPTION
This pull request includes changes to the `StatsSection` component in `src/components/Blocks/Stats/index.tsx` to improve the layout and styling. The most important changes include removing unnecessary padding from the section container, adding a border to each stat item, and adjusting the grid layout.

Styling and layout improvements:

* [`src/components/Blocks/Stats/index.tsx`](diffhunk://#diff-39000be884f7c6ad752bd4708c3e07148eed3488289627c0ca36c52c24350199L12-R21): Removed padding from the `div` containing the stats section.
* [`src/components/Blocks/Stats/index.tsx`](diffhunk://#diff-39000be884f7c6ad752bd4708c3e07148eed3488289627c0ca36c52c24350199L12-R21): Added a border to each stat item and adjusted the padding to improve the visual separation of items.
* [`src/components/Blocks/Stats/index.tsx`](diffhunk://#diff-39000be884f7c6ad752bd4708c3e07148eed3488289627c0ca36c52c24350199L12-R21): Added a `lg:divide-x` class to the grid container to add vertical dividers between columns at large screen sizes.