### PR TITLE
feat: add dynamic sitemap generation and robots.txt support with baseURL configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,4 @@ R2_BUCKET=
 
 
 BASE_URL=http://localhost:3000
+NEXT_PUBLIC_BASE_URL=http://localhost:3000

--- a/src/app/(frontend)/[locale]/(sitemaps)/sitemap.xml/route.ts
+++ b/src/app/(frontend)/[locale]/(sitemaps)/sitemap.xml/route.ts
@@ -1,0 +1,41 @@
+export const dynamic = 'force-static'
+
+import { __BASE_URL__ } from '@/const/baseUrl'
+import { Locale } from '@/types'
+import { generateSitemap, GenerateSitemapParams } from '@/utilities/generateSitemap'
+
+const sitemapData = (locale: Locale): GenerateSitemapParams['data'] => {
+  return [
+    {
+      url: `${__BASE_URL__}/${locale}`,
+      lastModifed: new Date(),
+      priority: 1,
+    },
+    {
+      url: `${__BASE_URL__}/${locale}/about`,
+      lastModifed: new Date(),
+      priority: 0.8,
+    },
+    {
+      url: `${__BASE_URL__}/${locale}/treatments`,
+      lastModifed: new Date(),
+      priority: 0.8,
+    },
+    {
+      url: `${__BASE_URL__}/${locale}/book-appointment`,
+      lastModifed: new Date(),
+      priority: 1,
+    },
+  ]
+}
+
+export async function GET(_: Request, { params }: { params: Promise<{ locale: Locale }> }) {
+  const { locale } = await params
+
+  const sitemap = generateSitemap({ data: sitemapData(locale) })
+  return new Response(sitemap, {
+    headers: {
+      'Content-Type': 'application/xml',
+    },
+  })
+}

--- a/src/app/(frontend)/[locale]/(sitemaps)/treatments-sitemap.xml/route.ts
+++ b/src/app/(frontend)/[locale]/(sitemaps)/treatments-sitemap.xml/route.ts
@@ -1,0 +1,59 @@
+import { unstable_cache } from 'next/cache'
+import { getPayload } from 'payload'
+import config from '@payload-config'
+import { generateSitemap, GenerateSitemapParams } from '@/utilities/generateSitemap'
+import { __BASE_URL__ } from '@/const/baseUrl'
+import { Locale } from '@/types'
+
+export const getCachedTreatmentsSitemap = (locale: Locale) =>
+  unstable_cache(
+    async (): Promise<GenerateSitemapParams['data']> => {
+      const payload = await getPayload({ config })
+
+      const treatments = await payload.find({
+        select: {
+          slug: true,
+          thumbnail: true,
+          updatedAt: true,
+        },
+        collection: 'treatments',
+        depth: 1,
+        where: {
+          _status: { equals: 'published' },
+        },
+        limit: 1000,
+        pagination: false,
+        locale,
+      })
+
+      return treatments.docs.map((treatment) => ({
+        url: `${__BASE_URL__}/${locale}/treatments/${treatment.slug}`,
+        lastModifed: treatment.updatedAt,
+        priority: 0.8,
+        images:
+          typeof treatment.thumbnail !== 'string'
+            ? [`${__BASE_URL__}${treatment.thumbnail.url}`].filter(
+                (image): image is string => !!image,
+              )
+            : [],
+      }))
+    },
+    ['treatments-sitemap', locale],
+    {
+      tags: ['treatments-sitemap'],
+    },
+  )
+
+export async function GET(_: Request, { params }: { params: Promise<{ locale: Locale }> }) {
+  const { locale } = await params
+
+  const treatmentsSitemap = await getCachedTreatmentsSitemap(locale)()
+
+  const sitemap = generateSitemap({ data: treatmentsSitemap })
+
+  return new Response(sitemap, {
+    headers: {
+      'Content-Type': 'application/xml',
+    },
+  })
+}

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,21 @@
+import { __BASE_URL__ } from '@/const/baseUrl'
+import type { MetadataRoute } from 'next'
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: '*',
+        allow: '/',
+        disallow: '/admin/',
+      },
+    ],
+    sitemap: [
+      `${__BASE_URL__}/bn-BD/sitemap.xml`,
+      `${__BASE_URL__}/en-US/sitemap.xml`,
+
+      `${__BASE_URL__}/bn-BD/treatments-sitemap.xml`,
+      `${__BASE_URL__}/en-US/treatments-sitemap.xml`,
+    ],
+  }
+}

--- a/src/const/baseUrl.ts
+++ b/src/const/baseUrl.ts
@@ -1,0 +1,1 @@
+export const __BASE_URL__ = process.env.NEXT_PUBLIC_BASE_URL || 'http://localhost:3000'

--- a/src/utilities/generateSitemap.ts
+++ b/src/utilities/generateSitemap.ts
@@ -1,0 +1,46 @@
+export type GenerateSitemapParams = {
+  data: {
+    url: string
+    lastModifed?: Date | string
+    priority?: number
+    changeFrequency?: 'always' | 'hourly' | 'daily' | 'weekly' | 'monthly' | 'yearly' | 'never'
+    images?: string[] | undefined
+  }[]
+}
+
+export function generateSitemap(params: GenerateSitemapParams): string {
+  let xml = '<?xml version="1.0" encoding="UTF-8"?>\n'
+  xml +=
+    '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">\n'
+
+  for (const item of params.data) {
+    xml += '  <url>\n'
+    xml += `    <loc>${item.url}</loc>\n`
+
+    if (item.lastModifed) {
+      const lastModified = new Date(item.lastModifed).toISOString()
+      xml += `    <lastmod>${lastModified}</lastmod>\n`
+    }
+
+    if (item.priority) {
+      xml += `    <priority>${item.priority}</priority>\n`
+    }
+
+    if (item.changeFrequency) {
+      xml += `    <changefreq>${item.changeFrequency}</changefreq>\n`
+    }
+
+    if (item.images?.length) {
+      for (const image of item.images) {
+        xml += '    <image:image>\n'
+        xml += `      <image:loc>${image}</image:loc>\n`
+        xml += '    </image:image>\n'
+      }
+    }
+
+    xml += '  </url>\n'
+  }
+
+  xml += '</urlset>'
+  return xml
+}


### PR DESCRIPTION
This pull request introduces several changes related to sitemap generation and base URL configuration. The most important changes include adding a new environment variable for the base URL, creating a utility function to generate sitemaps, and updating various routes to use these new utilities.

### Base URL Configuration:
* [`.env.example`](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cR11): Added `NEXT_PUBLIC_BASE_URL` to define the base URL for the application.
* [`src/const/baseUrl.ts`](diffhunk://#diff-b6bf8651fcc380cc44ff6ae82f2dbaf5f5ffffea7b3dbc27fea280db48191c1dR1): Introduced `__BASE_URL__` constant to use the environment variable `NEXT_PUBLIC_BASE_URL` or default to `http://localhost:3000`.

### Sitemap Generation:
* [`src/utilities/generateSitemap.ts`](diffhunk://#diff-88b155a06ba8912db3d16b5c3f72cb7dcaf6cfd52f6a6458e9d543ead79b9153R1-R46): Created `generateSitemap` function and `GenerateSitemapParams` type to generate XML sitemaps.
* `src/app/(frontend)/[locale]/(sitemaps)/sitemap.xml/route.ts`: Added route to generate the main sitemap using the new utility function. ([src/app/(frontend)/[locale]/(sitemaps)/sitemap.xml/route.tsR1-R41](diffhunk://#diff-ecb13347b303f7aa8e6e92a0a7350d848965b0e4e8fe2d1e3f9644ebcf8ce712R1-R41))
* `src/app/(frontend)/[locale]/(sitemaps)/treatments-sitemap.xml/route.ts`: Added route to generate the treatments sitemap, including caching and fetching treatment data. ([src/app/(frontend)/[locale]/(sitemaps)/treatments-sitemap.xml/route.tsR1-R59](diffhunk://#diff-d36c7752da5981bd1be6a1decab8fe0411d84195c6f3db4ea46944d4ee90da3aR1-R59))

### Robots Configuration:
* [`src/app/robots.ts`](diffhunk://#diff-ed9ec6703690885f59a70b98dc1bf064161c8d9065092c565092143c211f04bbR1-R21): Updated robots.txt generation to include the new sitemap URLs.